### PR TITLE
Wall Dragger and Note Shadow Updates, and Bug Fixes

### DIFF
--- a/Assets/MikuEditor/Scripts/CircuitLord/NoteDragger.cs
+++ b/Assets/MikuEditor/Scripts/CircuitLord/NoteDragger.cs
@@ -110,14 +110,14 @@ public class NoteDragger : MonoBehaviour {
 				waveCustom.targetOptional = segments;
 				waveCustom.RenderLine(true, true);
 			}			
-			List<Segment> segmentsList = Track.s_instance.SegmentsList.FindAll(x => x.measure == Track.CurrentSelectedMeasure && x.note.Type == selectedNote.note.Type);
+			List<Segment> segmentsList = Track.s_instance.SegmentsList.FindAll(x => (Mathf.Abs(x.measure-Track.CurrentSelectedMeasure)<Track.MeasureCheckTolerance) && x.note.Type == selectedNote.note.Type);
 			if(segmentsList == null || segmentsList.Count <= 0) { 
 				Debug.Log("Error finding segment!");
 			} else {
 				Note parentNote = segmentsList.First().note;
 				if (parentNote==null) Debug.Log("Error finding parent note!");
 				else {
-					float noteBeat = Track.s_instance.FindClosestNoteBeat(Mathf.RoundToInt(Track.s_instance.GetBeatMeasureByUnit(parentNote.Position[2])));
+					float noteBeat = Track.s_instance.FindClosestNoteBeat(Track.s_instance.GetBeatMeasureByUnit(parentNote.Position[2]));
 					// Instead of recording a change in position to an individual node, we have to record the before and after state of the parent note; otherwise there will be Undo errors when the moved node is the only node on the rail.
 					Track.HistoryChangeRailNodeParent(selectedNote.note.Type, noteBeat, new float[] {parentNote.Position[0], parentNote.Position[1], parentNote.Position[2]}, originNote.note.Segments, parentNote.Segments);
 				}

--- a/Assets/MikuEditor/Scripts/CircuitLord/NoteRayUtil.cs
+++ b/Assets/MikuEditor/Scripts/CircuitLord/NoteRayUtil.cs
@@ -16,7 +16,7 @@ public static class NoteRayUtil {
 
 			EditorNote draggableNote = new EditorNote();
 			
-			Debug.Log("Hit note name: " + hit.transform.gameObject.name);
+			//Debug.Log("Hit note name: " + hit.transform.gameObject.name);
 
 			//If it's a rail node segment.
 			if (hit.transform.gameObject.name.EndsWith("_Segment")) {

--- a/Assets/MikuEditor/Scripts/CircuitLord/RailEditor.cs
+++ b/Assets/MikuEditor/Scripts/CircuitLord/RailEditor.cs
@@ -74,7 +74,8 @@ public class RailEditor : MonoBehaviour {
 			History.changingHistory = changingHistoryBackup;
 		}
 		else {
-			Track.HistoryChangeRailNode(note.note.Type, false, Mathf.RoundToInt(Track.s_instance.GetBeatMeasureByUnit(note.noteGO.transform.position.z)), new float[] {note.noteGO.transform.position.x, note.noteGO.transform.position.y, note.noteGO.transform.position.z});
+			//Track.HistoryChangeRailNode(note.note.Type, false, Mathf.RoundToInt(3f*Track.s_instance.GetBeatMeasureByUnit(note.noteGO.transform.position.z))/3f, new float[] {note.noteGO.transform.position.x, note.noteGO.transform.position.y, note.noteGO.transform.position.z});
+			Track.HistoryChangeRailNode(note.note.Type, false, Track.s_instance.RoundToThird(Track.s_instance.GetBeatMeasureByUnit(note.noteGO.transform.position.z)), new float[] {note.noteGO.transform.position.x, note.noteGO.transform.position.y, note.noteGO.transform.position.z});
 			note.connectedNodes.Remove(note.noteGO.transform);
 			DestroyImmediate(note.noteGO);
 			if (waveCustom) {
@@ -217,7 +218,7 @@ public class RailEditor : MonoBehaviour {
 			foreach (Note n in notes) {
 				//If it's a rail start and it's the same note type as the user has selected.
 				if (n.Segments != null && n.Type == selectedNoteType) {
-					Debug.Log("Rail found! Note ID " + n.Id);
+					//Debug.Log("Rail found! Note ID " + n.Id);
 					
 					railStart.note = n;
 					railStart.type = EditorNoteType.RailStart;

--- a/Assets/MikuEditor/Scripts/LittleAsi/WallDragger.cs
+++ b/Assets/MikuEditor/Scripts/LittleAsi/WallDragger.cs
@@ -20,11 +20,9 @@ public class WallDragger : MonoBehaviour {
 	private void Update() {
 		if (isDragging && selectedWall.exists) {
 			Vector3 mousePos = GetPosOnGridFromMouse();
-			if (mousePos.z != 0) { // If the mouse moves out of the grid boundary, don't adjust the wall position
-				Vector3 adjustedPos = mousePos-mouseWallOffset;
-				if (notesArea.SnapToGrip) adjustedPos = gridManager.GetNearestPointOnGrid(adjustedPos);
-				selectedWall.wallGO.transform.position = new Vector3(adjustedPos.x, adjustedPos.y, selectedWall.wallGO.transform.position.z);
-			}
+			Vector3 adjustedPos = mousePos-mouseWallOffset;
+			if (notesArea.SnapToGrip) adjustedPos = gridManager.GetNearestPointOnGrid(adjustedPos);
+			selectedWall.wallGO.transform.position = new Vector3(adjustedPos.x, adjustedPos.y, selectedWall.wallGO.transform.position.z);
 			if (selectedWall.exists && Input.GetMouseButtonUp(0)) {
 				EndCurrentDrag();
 			}
@@ -108,7 +106,7 @@ public class WallDragger : MonoBehaviour {
 	private Vector3 GetPosOnGridFromMouse() {
 		Ray ray = activatedCamera.ScreenPointToRay(Input.mousePosition);
 		RaycastHit hit;
-		if (Physics.Raycast(ray, out hit, 50f, gridLayer)) {
+		if (Physics.Raycast(ray, out hit, 50f, (wallsLayer | gridLayer))) {
 			Vector3 pos = hit.point;
 			return pos;
 		}


### PR DESCRIPTION
Fixed several bugs for intervals at fractions of 1/3:
- Beat will no longer slowly drift off-time as the user scrolls through the timeline at fractions of 1/3 interval.
- Interacting with notes at fractions of 1/3 should no longer cause null pointer errors.

Wall dragger updated to allow mouse movement outside of the grid.

The last note shadow now works throughout the song, not only after the last note.